### PR TITLE
secretary becomes house chair

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -390,6 +390,8 @@ helping to run the first meeting of the spring term.
 \item If a House Officer position becomes vacant mid-term, the resigning officer should be reminded of his/her duty to train the replacement. The Chair of the House should notify the House that the spot has become vacant and that they may demonstrate interest within the week. At the end of the week, one of two outcomes has occurred: (a) 1 or 0 people have contacted the chair. In this case, the chair is permitted to appoint said person (if one is found) to the office in question. The Chair must ratify the selection at the next House meeting with a simple majority vote; (b) 2 or more people have contacted the chair. In this case, the chair (with the help of other officers) must administer a one-week mid-term election for the House to select between the candidates. Additionally, if the end of the one-week special election
 would fall within one month of the end of a regular election, then the House Chair may exercise discretion in deciding whether to run a vote / appoint directly / wait for the main election.
 
+\item The previous section, Article 5 Section 1 Item 8, does not apply to the instance in which the Secretary choses to assume the role of House Chair permanently.
+
 \item Provisionally elected officers take office immediately upon election and fill the vacant office until the time of the next regular election.
 
 \end{enumerate}


### PR DESCRIPTION
Previously approved by the House on March 10th, 2013 due to situations that arose this year. Clarifies conflicting information between executive officer succession and committee chair succession. If the house chair leaves office, the secretary can take the position permanently or fill the role till a new house chair is elected.
